### PR TITLE
[fix] made date picker field a controlled component and other fixes

### DIFF
--- a/lib/src/Body/EditCell.component.tsx
+++ b/lib/src/Body/EditCell.component.tsx
@@ -59,7 +59,7 @@ const DEFAULT_VALIDATORS: Record<NonNullable<EditDataTypes>, (value: any, option
     if (isNaN(new Date(value).getTime())) throw createDTError("Value should be a valid date");
   },
   select: (value, options) => {
-    if (options.some((o) => (typeof o === "string" ? o === value : o.value === value))) {
+    if (options.every((o) => (typeof o === "string" ? o !== value : o.value !== value))) {
       throw createDTError("Value should be one of the available options");
     }
   },

--- a/lib/src/Body/EditCell.component.tsx
+++ b/lib/src/Body/EditCell.component.tsx
@@ -50,14 +50,13 @@ const DEFAULT_VALIDATORS: Record<NonNullable<EditDataTypes>, (value: any, option
     if (typeof value !== "string") throw createDTError("Value should be a string");
   },
   number: (value) => {
-    if (!isNaN(value)) throw createDTError("Value should be a valid number");
+    if (isNaN(value)) throw createDTError("Value should be a valid number");
   },
   boolean: (value) => {
     if (typeof value !== "boolean") throw createDTError("Value should be a boolean");
   },
   date: (value) => {
-    if (!isNaN(new Date(value as string | number | Date).getTime()))
-      throw createDTError("Value should be a valid date");
+    if (isNaN(new Date(value).getTime())) throw createDTError("Value should be a valid date");
   },
   select: (value, options) => {
     if (options.some((o) => (typeof o === "string" ? o === value : o.value === value))) {

--- a/lib/src/Fields/DatePicker.component.tsx
+++ b/lib/src/Fields/DatePicker.component.tsx
@@ -1,0 +1,31 @@
+import { DatePicker as MUIDatePicker, DatePickerProps as MUIDatePickerProps } from "@material-ui/pickers";
+import React, { useCallback, useEffect, useState } from "react";
+
+interface DatePickerProps extends Omit<MUIDatePickerProps, "value"> {
+  defaultValue?: MUIDatePickerProps["value"];
+  value?: MUIDatePickerProps["value"];
+}
+
+const DatePicker: React.FC<DatePickerProps> = ({ defaultValue, value, onChange, ...props }) => {
+  const [val, setVal] = useState(defaultValue || value || null);
+
+  const handleChange = useCallback(
+    (date) => {
+      onChange(date);
+      if (typeof value === "undefined") {
+        setVal(date || null);
+      }
+    },
+    [onChange, value],
+  );
+
+  useEffect(() => {
+    if (typeof defaultValue === "undefined") {
+      setVal(value || null);
+    }
+  }, [defaultValue, value]);
+
+  return <MUIDatePicker {...props} value={val} onChange={handleChange} />;
+};
+
+export default DatePicker;

--- a/lib/src/Fields/SimpleSelect.component.tsx
+++ b/lib/src/Fields/SimpleSelect.component.tsx
@@ -12,10 +12,10 @@ import {
 import PropTypes from "prop-types";
 import React, { ChangeEventHandler, PropsWithChildren, useCallback, useEffect, useMemo, useState } from "react";
 
-export type SelectFieldOption = { label: string; value: string };
-export type SimpleSelectChangeHandler<T extends SelectFieldOption> = (value: T | null) => void;
+export type SelectOptionObject = { label: string; value: string };
+export type SimpleSelectChangeHandler<T extends SelectOptionObject> = (value: T | null) => void;
 
-interface SimpleSelectProps<T extends SelectFieldOption> extends Omit<SelectProps, "onChange"> {
+interface SimpleSelectProps<T extends SelectOptionObject> extends Omit<SelectProps, "onChange"> {
   options: Array<T | string>;
   onChange: SimpleSelectChangeHandler<T>;
   helperText?: string | null;
@@ -38,7 +38,7 @@ const useStyles = makeStyles(
  *
  * @component
  */
-const SimpleSelectField = <T extends SelectFieldOption>({
+const SimpleSelect = <T extends SelectOptionObject>({
   placeholder,
   options,
   value,
@@ -111,7 +111,7 @@ const SimpleSelectField = <T extends SelectFieldOption>({
     </FormControl>
   );
 };
-SimpleSelectField.propTypes = {
+SimpleSelect.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.string,
@@ -124,4 +124,4 @@ SimpleSelectField.propTypes = {
   onChange: PropTypes.func.isRequired,
 };
 
-export default SimpleSelectField;
+export default SimpleSelect;

--- a/lib/src/Filter/FilterRow.component.tsx
+++ b/lib/src/Filter/FilterRow.component.tsx
@@ -5,10 +5,10 @@ import clsx from "clsx";
 import PropTypes from "prop-types";
 import React, { PropsWithChildren, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { BaseData, FilterValue } from "..";
+import SimpleSelect, { SimpleSelectChangeHandler } from "../Fields/SimpleSelect.component";
 import TableContext, { TableState } from "../table.context";
 import type { ActiveFilter, NullableActiveFilter, NullableDataTypes } from "../table.types";
 import { FilterValuePropTypes, OPERATORS } from "../_dataTable.consts";
-import SimpleSelectField, { SimpleSelectChangeHandler } from "./SimpleSelectField.component";
 import ValueField from "./ValueField.component";
 
 interface Props {
@@ -157,7 +157,7 @@ const FilterRow = <RowType extends BaseData, AllDataType extends RowType[]>({
       <div>
         <div className={classes.field}>
           <Typography variant="caption">Column</Typography>
-          <SimpleSelectField
+          <SimpleSelect
             name="path"
             onChange={handleColumnChange}
             value={filter.path}
@@ -169,7 +169,7 @@ const FilterRow = <RowType extends BaseData, AllDataType extends RowType[]>({
         </div>
         <div className={clsx([classes.field, classes.operatorField])}>
           <Typography variant="caption">Operator</Typography>
-          <SimpleSelectField
+          <SimpleSelect
             name="operator"
             onChange={handleOperatorChange}
             value={filter.operator}

--- a/lib/src/Filter/ValueField.component.tsx
+++ b/lib/src/Filter/ValueField.component.tsx
@@ -1,12 +1,12 @@
 import { debounce, TextField, Typography } from "@material-ui/core";
-import { DatePicker } from "@material-ui/pickers";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
 import PropTypes from "prop-types";
 import React, { ChangeEvent, PropsWithChildren, useCallback, useEffect, useMemo, useState } from "react";
+import DatePicker from "../Fields/DatePicker.component";
+import SimpleSelect, { SelectOptionObject } from "../Fields/SimpleSelect.component";
 import type { ActiveFilter, NullableActiveFilter } from "../table.types";
 import { getFilterTypeConvertors } from "../utils";
 import { BOOLEAN_OPTIONS, FilterValuePropTypes } from "../_dataTable.consts";
-import SimpleSelectField, { SelectFieldOption } from "./SimpleSelectField.component";
 
 type FilterValueType<T extends ActiveFilter["type"] | NullableActiveFilter["type"]> = T extends "string"
   ? string
@@ -57,7 +57,7 @@ const ValueField = <
     [filter.value, hasError],
   );
 
-  const handleSelectChange = useCallback((selected: SelectFieldOption | null) => {
+  const handleSelectChange = useCallback((selected: SelectOptionObject | null) => {
     if (!selected) return setFilterValue(null);
     setFilterValue(selected.value === "true");
   }, []);
@@ -77,11 +77,12 @@ const ValueField = <
   const field = useMemo(() => {
     switch (filter.type) {
       case "boolean":
-        return <SimpleSelectField {...commonProps} onChange={handleSelectChange} options={BOOLEAN_OPTIONS} />;
+        return <SimpleSelect {...commonProps} onChange={handleSelectChange} options={BOOLEAN_OPTIONS} />;
       case "date":
         return (
           <DatePicker
-            {...(commonProps as any)}
+            {...commonProps}
+            defaultValue={commonProps.defaultValue as MaterialUiPickersDate}
             onChange={handleDateChange}
             variant="dialog"
             inputVariant={commonProps.variant}

--- a/lib/src/_dataTable.consts.ts
+++ b/lib/src/_dataTable.consts.ts
@@ -1,8 +1,8 @@
 import PropTypes from "prop-types";
-import { SelectFieldOption } from "./Filter/SimpleSelectField.component";
+import { SelectOptionObject } from "./Fields/SimpleSelect.component";
 import { Operator } from "./table.types";
 
-export const BOOLEAN_OPTIONS: SelectFieldOption[] = ["true", "false"].map((value) => ({ value, label: value }));
+export const BOOLEAN_OPTIONS: SelectOptionObject[] = ["true", "false"].map((value) => ({ value, label: value }));
 
 export const DATA_TYPES = ["string", "number", "boolean", "date"] as const;
 

--- a/lib/src/table.types.ts
+++ b/lib/src/table.types.ts
@@ -2,7 +2,7 @@ import type { IconButtonProps, TablePaginationProps, TableProps as MUITableProps
 import type React from "react";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
 import type { LiteralUnion, RequireExactlyOne } from "type-fest";
-import { SelectFieldOption } from "./Filter/SimpleSelectField.component";
+import { SelectOptionObject } from "./Fields/SimpleSelect.component";
 import { BASE_OPERATORS, DATA_TYPES } from "./_dataTable.consts";
 
 export interface BaseData {
@@ -212,6 +212,8 @@ export interface EditComponentProps<T = any> {
   disabled: boolean;
 }
 
+export type SelectOption = SelectOptionObject | string;
+
 export interface EditableOptions<EditType, RowType extends BaseData, AllDataType extends RowType[]> {
   path: PathValueType<RowType>;
   /**
@@ -236,7 +238,7 @@ export interface EditableOptions<EditType, RowType extends BaseData, AllDataType
   /**
    * Options or a function that returns the options for the select component when `type` is `"select"`.
    */
-  selectOptions?: SelectFieldOption[] | ((data: RowType, allData: AllDataType) => SelectFieldOption[]);
+  selectOptions?: SelectOption[] | ((data: RowType, allData: AllDataType) => SelectOption[]);
   /**
    * Default value if the value at the `path` is `undefined` or `null`.
    */


### PR DESCRIPTION
- Renamed `SelectFieldOption` to `SelectOptionObject`
- Changed the `validate` function for the edit cell component to use a new `DEFAULT_VALIDATORS` map
- [fix] for edit field select validation to enable it for options which are plain strings rather than the `SelectOptionObject`
- Made a custom `DatePicker` component to handle controlled and uncontrolled use cases
- Moved `SimpleSelectField` to `Fields/`
- Renamed `SimpleSelectField` function to `SimpleSelect`
- Changed the `ValueField` to use the new custom `DatePicker` field
- Type changes